### PR TITLE
Dockerize dev environment and add quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker Compose Up
+        run: docker compose -f infra/compose.yaml up -d db
+      - name: Wait for DB
+        run: sleep 5
+      - name: Migrate
+        run: docker compose -f infra/compose.yaml exec -T db psql -U bankmatch -d bankmatch -f /migrations/0001_init.sql
+      - name: Ingest
+        run: docker compose -f infra/compose.yaml run --rm etl bash -lc "pip install -r app/requirements.txt && python etl/ingest_csv.py --dsn postgres://bankmatch:bankmatch@db:5432/bankmatch --csv data/templates/products_template.csv"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,40 @@
-.PHONY: up down migrate ingest
-up:
-	docker compose -f infra/compose.yaml up -d
-down:
-	docker compose -f infra/compose.yaml down -v
+.PHONY: check up down logs migrate ingest psql help
+
+DC := docker compose -f infra/compose.yaml
+
+help:
+	@echo "Targets:"
+	@echo "  make check    - verify docker/compose availability"
+	@echo "  make up       - start Postgres"
+	@echo "  make migrate  - run SQL migrations inside the db container"
+	@echo "  make ingest   - run CSV -> Postgres ingestion via ETL container"
+	@echo "  make logs     - tail db logs"
+	@echo "  make down     - stop and remove containers/volumes"
+
+check:
+	@command -v docker >/dev/null 2>&1 || { echo >&2 "❌ Docker not installed. Install Docker Desktop and retry."; exit 1; }
+	@docker compose version >/dev/null 2>&1 || { echo >&2 "❌ docker compose not available. Update Docker Desktop."; exit 1; }
+	@echo "✅ Docker OK"
+
+up: check
+	$(DC) up -d db
+	@echo "⏳ Waiting for Postgres to be healthy..."; sleep 3
+	$(DC) ps
+
+logs:
+	$(DC) logs -f db
+
 migrate:
-	psql "postgres://bankmatch:bankmatch@localhost:5432/bankmatch" -f db/migrations/0001_init.sql
+	# run migration inside the db container using psql from the Postgres image
+	$(DC) exec -T db psql -U bankmatch -d bankmatch -f /migrations/0001_init.sql
+	@echo "✅ Migrations applied"
+
 ingest:
-	python etl/ingest_csv.py --dsn "postgres://bankmatch:bankmatch@localhost:5432/bankmatch" --csv data/templates/products_template.csv
+	# run ETL inside the python container; install deps in-container, then run script
+	$(DC) run --rm etl "pip install -r app/requirements.txt && python etl/ingest_csv.py --dsn postgres://bankmatch:bankmatch@db:5432/bankmatch --csv data/templates/products_template.csv"
+
+psql:
+	$(DC) exec -it db psql -U bankmatch -d bankmatch
+
+down:
+	$(DC) down -v

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-﻿ # bank-match 
+# bank-match
+
 פלטפורמה להתאמת לקוחות למוצרי הלוואות בנקאיים בארה"ב.
+
+## Quickstart (Docker-only)
+
+**Prereqs:** Install Docker Desktop (Mac/Win) or Docker Engine + Compose (Linux).
+
+```bash
+# 1) Optional environment check
+./scripts/dev/check_env.sh
+
+# 2) Start Postgres in Docker
+make up
+
+# 3) Apply DB migrations (runs psql inside the db container)
+make migrate
+
+# 4) Load sample data (runs Python inside a container; no local pip needed)
+make ingest
+
+# 5) (Optional) open a psql shell in the db container
+make psql
+
+# 6) Tear down
+make down
+```
+
+**If you prefer local Python:** create a venv and `pip install -r app/requirements.txt` then run `etl/ingest_csv.py` with a local DSN.
+
+Troubleshooting:
+
+* `docker: command not found` → Install Docker Desktop and restart your shell.
+* `psql: not found` → Not needed locally anymore; we run it inside the container.
+* Ingest fails with pandas/psycopg → rerun `make ingest` (it reinstalls inside the container).

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
-psycopg2-binary==2.9.9
+# Compatible pins to avoid platform resolution issues
+psycopg2-binary>=2.9.7,<3
 pandas==2.2.2
-python-dateutil==2.9.0
+python-dateutil==2.9.0.post0

--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -8,5 +8,18 @@ services:
     ports: ["5432:5432"]
     volumes:
       - dbdata:/var/lib/postgresql/data
+      - ../db/migrations:/migrations:ro
+
+  etl:
+    image: python:3.11-slim
+    working_dir: /workspace
+    volumes:
+      - ..:/workspace
+    environment:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PIP_NO_CACHE_DIR: "1"
+    # Install deps on each run for simplicity; can be optimized with a Dockerfile later.
+    entrypoint: ["bash", "-lc"]
+
 volumes:
   dbdata:

--- a/scripts/dev/check_env.sh
+++ b/scripts/dev/check_env.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+echo "Checking Docker..."
+if ! command -v docker >/dev/null 2>&1; then
+  echo "❌ Docker not installed. Get Docker Desktop: https://www.docker.com/products/docker-desktop"
+  exit 1
+fi
+echo "Docker OK"
+echo "Checking docker compose..."
+if ! docker compose version >/dev/null 2>&1; then
+  echo "❌ docker compose not available. Update Docker Desktop."
+  exit 1
+fi
+echo "docker compose OK"
+echo "✅ Environment looks good."


### PR DESCRIPTION
## Summary
- Pin Python dependencies for container-friendly installs
- Add Docker Compose services for Postgres and ETL runner
- Run migrations and data ingestion via Makefile targets and new helper script
- Document Docker-only quickstart and add CI smoke test

## Testing
- `./scripts/dev/check_env.sh` *(fails: Docker not installed)*
- `make check` *(fails: Docker not installed)*
- `make up` *(fails: Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68b4ab7f8ad8832789733566259df866