### PR TITLE
Add JSON to CSV converter for research output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,20 @@ jobs:
         run: docker compose -f infra/compose.yaml exec -T db psql -U bankmatch -d bankmatch -f /migrations/0001_init.sql
       - name: Ingest
         run: docker compose -f infra/compose.yaml run --rm etl bash -lc "pip install -r app/requirements.txt && python etl/ingest_csv.py --dsn postgres://bankmatch:bankmatch@db:5432/bankmatch --csv data/templates/products_template.csv"
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker Compose Up (db)
+        run: docker compose -f infra/compose.yaml up -d db
+      - name: Wait for DB
+        run: sleep 5
+      - name: Migrate
+        run: docker compose -f infra/compose.yaml exec -T db psql -U bankmatch -d bankmatch -f /migrations/0001_init.sql
+      - name: Convert JSON -> CSV
+        run: docker compose -f infra/compose.yaml run --rm etl bash -lc "python etl/convert_json_to_csv.py data/sample_batch.json data/sample_batch.csv"
+      - name: Ingest CSV
+        run: docker compose -f infra/compose.yaml run --rm etl bash -lc "python etl/ingest_csv.py --dsn postgres://bankmatch:bankmatch@db:5432/bankmatch --csv data/sample_batch.csv"
+      - name: Verify counts
+        run: docker compose -f infra/compose.yaml exec -T db psql -U bankmatch -d bankmatch -c "SELECT count(*) AS banks FROM banks; SELECT count(*) AS products FROM products;"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,37 @@ Troubleshooting:
 * `docker: command not found` → Install Docker Desktop and restart your shell.
 * `psql: not found` → Not needed locally anymore; we run it inside the container.
 * Ingest fails with pandas/psycopg → rerun `make ingest` (it reinstalls inside the container).
+
+### Batch import (JSON → CSV → DB)
+
+**Option A (Make):**
+```bash
+make batch IN=data/batch_001.json OUT=data/batch_001.csv
+```
+
+**Option B (Windows PowerShell):**
+
+```powershell
+\.\scripts\dev\batch.ps1 -InJson data\batch_001.json -OutCsv data\batch_001.csv
+```
+
+The command will:
+
+- convert JSON → CSV with the extended 42-column schema,
+- ingest into Postgres in Docker,
+- print bank/product counts for verification.
+
+### Quick demo (matching)
+
+```bash
+make up
+make migrate
+make migrate2
+# load sample criteria and customers
+docker compose -f infra/compose.yaml exec -T db psql -U bankmatch -d bankmatch -f data/sample_criteria.sql
+docker compose -f infra/compose.yaml exec -T db psql -U bankmatch -d bankmatch -f data/sample_customer.sql
+make match CID=1
+```
+
+The `match` command filters products by eligibility, underwriting, and deal
+constraints, returning the best-ranked matches for the given customer profile.

--- a/data/sample_batch.json
+++ b/data/sample_batch.json
@@ -1,0 +1,42 @@
+[
+  {
+    "bank_legal_name": "Sample Bank A",
+    "fdic_certificate": 10001,
+    "website": "https://a.example.com",
+    "lending_footprint": "US",
+    "product_type": "term_loan",
+    "purpose_allowed": "working capital"
+  },
+  {
+    "bank_legal_name": "Sample Bank B",
+    "fdic_certificate": 10002,
+    "website": "https://b.example.com",
+    "lending_footprint": "US",
+    "product_type": "term_loan",
+    "purpose_allowed": "equipment purchase"
+  },
+  {
+    "bank_legal_name": "Sample Bank C",
+    "fdic_certificate": 10003,
+    "website": "https://c.example.com",
+    "lending_footprint": "US",
+    "product_type": "line_of_credit",
+    "purpose_allowed": "inventory"
+  },
+  {
+    "bank_legal_name": "Sample Bank D",
+    "fdic_certificate": 10004,
+    "website": "https://d.example.com",
+    "lending_footprint": "US",
+    "product_type": "line_of_credit",
+    "purpose_allowed": "real estate"
+  },
+  {
+    "bank_legal_name": "Sample Bank E",
+    "fdic_certificate": 10005,
+    "website": "https://e.example.com",
+    "lending_footprint": "US",
+    "product_type": "term_loan",
+    "purpose_allowed": "expansion"
+  }
+]

--- a/data/sample_criteria.sql
+++ b/data/sample_criteria.sql
@@ -1,0 +1,29 @@
+-- Sample product criteria for matching demo
+-- Assumes products with IDs 1 and 2 already exist (e.g., from ingested sample batch)
+
+INSERT INTO product_eligibility (
+  product_id, allowed_entities, allowed_industries, excluded_industries,
+  geographic_footprint, excluded_states, min_years_in_business,
+  min_annual_revenue_usd, requires_existing_relationship, notes
+) VALUES
+(1, 'LLC,S-Corp', 'Restaurants,Manufacturing', 'Cannabis', NULL, 'NV', 2, 100000, false, NULL),
+(2, 'LLC,S-Corp', NULL, NULL, NULL, NULL, 1, 50000, false, NULL);
+
+INSERT INTO product_underwriting (
+  product_id, min_personal_credit_score, min_business_credit_score, min_dscr,
+  min_current_ratio, max_debt_to_equity, cashflow_positive_required,
+  negative_balance_days_avg, negative_balance_longest_streak,
+  negative_balance_max_overdraft_usd, documents_required
+) VALUES
+(1, 680, 650, 1.2, 1.1, 3.0, true, 3, 5, 5000, NULL),
+(2, 700, 670, 1.3, 1.1, 2.5, true, 2, 4, 3000, NULL);
+
+INSERT INTO product_collateral (
+  product_id, collateral_required, eligible_collateral_types,
+  max_ltv_real_estate, max_ltv_equipment, max_ltv_receivables, max_ltv_inventory,
+  personal_guarantee, guarantee_type, purpose_allowed,
+  decision_timeline_prequal_days, decision_timeline_underwriting_days,
+  average_time_to_fund_days, special_conditions
+) VALUES
+(1, 'Case-by-case', 'RealEstate,Equipment', 80, 70, NULL, NULL, 'Required', 'Personal', 'WorkingCapital,Equipment', 5, 10, 15, NULL),
+(2, 'Yes', 'Equipment', 70, 80, NULL, NULL, 'Required', 'Personal', 'Equipment', 7, 14, 30, NULL);

--- a/data/sample_customer.sql
+++ b/data/sample_customer.sql
@@ -1,0 +1,13 @@
+-- Sample customer profiles for matching demo
+INSERT INTO customer_profiles (
+  legal_name, entity_type, industry, state, years_in_business,
+  annual_revenue_usd, personal_credit_score, business_credit_score,
+  dscr, current_ratio, debt_to_equity, cashflow_positive,
+  negative_balance_days_avg, negative_balance_longest_streak,
+  negative_balance_max_overdraft_usd, requested_product_type,
+  requested_amount_usd, use_of_proceeds
+) VALUES
+('Acme Restaurants', 'LLC', 'Restaurants', 'CA', 3, 500000, 700, 660,
+ 1.3, 1.2, 2.5, true, 2, 3, 3000, 'Line_of_Credit', 150000, 'WorkingCapital'),
+('Widget Manufacturing', 'S-Corp', 'Manufacturing', 'NY', 5, 2000000, 720, 680,
+ 1.5, 1.3, 1.8, true, 1, 2, 2000, 'Term_Loan', 500000, 'Equipment');

--- a/db/migrations/0002_match_schema.sql
+++ b/db/migrations/0002_match_schema.sql
@@ -1,0 +1,71 @@
+-- 0002_match_schema.sql
+
+-- Eligibility — prefilter ("gate") criteria per product
+CREATE TABLE IF NOT EXISTS product_eligibility (
+  product_id INTEGER PRIMARY KEY REFERENCES products(id) ON DELETE CASCADE,
+  allowed_entities TEXT,
+  allowed_industries TEXT,
+  excluded_industries TEXT,
+  geographic_footprint TEXT,
+  excluded_states TEXT,
+  min_years_in_business NUMERIC,
+  min_annual_revenue_usd NUMERIC,
+  requires_existing_relationship BOOLEAN,
+  notes TEXT
+);
+
+-- Underwriting — basic credit requirements per product
+CREATE TABLE IF NOT EXISTS product_underwriting (
+  product_id INTEGER PRIMARY KEY REFERENCES products(id) ON DELETE CASCADE,
+  min_personal_credit_score NUMERIC,
+  min_business_credit_score NUMERIC,
+  min_dscr NUMERIC,
+  min_current_ratio NUMERIC,
+  max_debt_to_equity NUMERIC,
+  cashflow_positive_required BOOLEAN,
+  negative_balance_days_avg NUMERIC,
+  negative_balance_longest_streak NUMERIC,
+  negative_balance_max_overdraft_usd NUMERIC,
+  documents_required TEXT
+);
+
+-- Deal & Collateral — structure and collateral expectations
+CREATE TABLE IF NOT EXISTS product_collateral (
+  product_id INTEGER PRIMARY KEY REFERENCES products(id) ON DELETE CASCADE,
+  collateral_required TEXT,
+  eligible_collateral_types TEXT,
+  max_ltv_real_estate NUMERIC,
+  max_ltv_equipment NUMERIC,
+  max_ltv_receivables NUMERIC,
+  max_ltv_inventory NUMERIC,
+  personal_guarantee TEXT,
+  guarantee_type TEXT,
+  purpose_allowed TEXT,
+  decision_timeline_prequal_days INTEGER,
+  decision_timeline_underwriting_days INTEGER,
+  average_time_to_fund_days INTEGER,
+  special_conditions TEXT
+);
+
+-- Customer profiles — minimal inputs for quick in-office matching
+CREATE TABLE IF NOT EXISTS customer_profiles (
+  id SERIAL PRIMARY KEY,
+  legal_name TEXT,
+  entity_type TEXT,
+  industry TEXT,
+  state TEXT,
+  years_in_business NUMERIC,
+  annual_revenue_usd NUMERIC,
+  personal_credit_score NUMERIC,
+  business_credit_score NUMERIC,
+  dscr NUMERIC,
+  current_ratio NUMERIC,
+  debt_to_equity NUMERIC,
+  cashflow_positive BOOLEAN,
+  negative_balance_days_avg NUMERIC,
+  negative_balance_longest_streak NUMERIC,
+  negative_balance_max_overdraft_usd NUMERIC,
+  requested_product_type TEXT,
+  requested_amount_usd NUMERIC,
+  use_of_proceeds TEXT
+);

--- a/etl/convert_json_to_csv.py
+++ b/etl/convert_json_to_csv.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Convert research JSON output to normalized CSV.
+
+Usage:
+    python etl/convert_json_to_csv.py input.json output.csv
+
+The input JSON is expected to be a list of dictionaries describing loan
+products gathered from research prompts. The script normalizes this data to the
+extended CSV schema required by the ingestion pipeline. Missing fields are
+filled with "Unknown/Not disclosed" and the CSV columns are written in a fixed
+order.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import csv
+from typing import Any, Dict, List
+
+# Fixed schema/column order
+COLUMNS: List[str] = [
+    "bank_legal_name",
+    "fdic_certificate",
+    "website",
+    "lending_footprint",
+    "excluded_states",
+    "product_type",
+    "purpose_allowed",
+    "min_loan_amount_usd",
+    "max_loan_amount_usd",
+    "rate_structure",
+    "interest_rate_min",
+    "interest_rate_max",
+    "rate_floor_or_spread",
+    "introductory_rate",
+    "loan_term_months_min",
+    "loan_term_months_max",
+    "amortization_type",
+    "min_years_in_business",
+    "min_annual_revenue_usd",
+    "min_personal_credit_score",
+    "min_dscr",
+    "other_financial_ratios",
+    "collateral_required",
+    "eligible_collateral_types",
+    "max_ltv_real_estate",
+    "max_ltv_equipment",
+    "max_ltv_receivables",
+    "max_ltv_inventory",
+    "personal_guarantee",
+    "guarantee_type",
+    "origination_fee",
+    "annual_fee",
+    "other_fees",
+    "prepayment_penalty",
+    "decision_timeline_prequal_days",
+    "decision_timeline_underwriting_days",
+    "average_time_to_fund_days",
+    "industry_restrictions",
+    "special_conditions",
+    "source_url",
+    "last_verified",
+]
+
+FALLBACK_VALUE = "Unknown/Not disclosed"
+
+
+def load_json(path: str) -> List[Dict[str, Any]]:
+    """Load JSON from *path* and ensure it is a list of dicts."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as exc:  # pragma: no cover - simple error path
+        raise SystemExit(f"Failed to read JSON from {path}: {exc}")
+
+    if isinstance(data, dict):
+        # Occasionally the JSON might be wrapped; try to use values if possible
+        # but fall back to treating as a single record
+        if len(data) == 1 and isinstance(next(iter(data.values())), list):
+            data = next(iter(data.values()))
+        else:
+            data = [data]
+
+    if not isinstance(data, list):
+        raise SystemExit("Input JSON must be a list of objects")
+
+    # Ensure each element is a dict
+    cleaned = []
+    for idx, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise SystemExit(f"Element at index {idx} is not an object")
+        cleaned.append(item)
+    return cleaned
+
+
+def normalize_record(rec: Dict[str, Any]) -> Dict[str, str]:
+    """Return a normalized record with all COLUMNS present."""
+    normalized: Dict[str, str] = {}
+    for col in COLUMNS:
+        val = rec.get(col)
+        if val is None or val == "":
+            normalized[col] = FALLBACK_VALUE
+        else:
+            # Convert lists/dicts to JSON strings to avoid CSV issues
+            if isinstance(val, (list, dict)):
+                normalized[col] = json.dumps(val)
+            else:
+                normalized[col] = str(val)
+    return normalized
+
+
+def convert_json_to_csv(input_path: str, output_path: str) -> int:
+    """Read *input_path*, write CSV to *output_path*, and return row count."""
+    records = load_json(input_path)
+    rows = [normalize_record(rec) for rec in records]
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return len(rows)
+
+
+def main(argv: List[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(description="Convert research JSON to CSV")
+    ap.add_argument("input", help="Path to input JSON file")
+    ap.add_argument("output", help="Path to output CSV file")
+    args = ap.parse_args(argv)
+
+    count = convert_json_to_csv(args.input, args.output)
+    print(f"Converted {count} products into {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/match_customer.py
+++ b/etl/match_customer.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Match customer profiles to bank products based on eligibility, underwriting,
+and deal/collateral criteria.
+
+The script can take a ``--customer-id`` referencing ``customer_profiles`` in the
+DB or accept inline parameters describing the customer. It performs three
+filtering stages and ranks surviving products with a simple score.
+
+Example (Dockerised):
+    docker compose -f infra/compose.yaml run --rm etl bash -lc \
+      "python etl/match_customer.py --dsn postgres://bankmatch:bankmatch@db:5432/bankmatch \
+       --customer-id 1 --top 10"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Dict, List, Tuple, Any
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+# Weights for scoring (very lightweight heuristic)
+W_FICO = 0.25
+W_DSCR = 0.25
+W_AMOUNT = 0.25
+W_NEG_DAYS = 0.25
+
+
+def parse_csv(value: Any) -> List[str]:
+    """Split comma-separated strings into a list of trimmed tokens."""
+    if not value:
+        return []
+    return [v.strip() for v in str(value).split(",") if v.strip()]
+
+
+def fetch_customer(conn, customer_id: int) -> Dict[str, Any]:
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    cur.execute("SELECT * FROM customer_profiles WHERE id = %s", (customer_id,))
+    row = cur.fetchone()
+    if not row:
+        raise SystemExit(f"Customer id {customer_id} not found")
+    return dict(row)
+
+
+def fetch_products(conn, product_type: str) -> List[Dict[str, Any]]:
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    cur.execute(
+        """
+        SELECT p.id, b.legal_name AS bank_name, p.product_type,
+               p.min_loan_amount_usd, p.max_loan_amount_usd,
+               b.lending_footprint AS bank_footprint,
+               e.allowed_entities, e.allowed_industries, e.excluded_industries,
+               e.geographic_footprint, e.excluded_states,
+               e.min_years_in_business, e.min_annual_revenue_usd,
+               e.requires_existing_relationship,
+               u.min_personal_credit_score, u.min_business_credit_score, u.min_dscr,
+               u.min_current_ratio, u.max_debt_to_equity, u.cashflow_positive_required,
+               u.negative_balance_days_avg, u.negative_balance_longest_streak,
+               u.negative_balance_max_overdraft_usd,
+               c.purpose_allowed AS deal_purpose_allowed,
+               c.collateral_required, c.eligible_collateral_types,
+               c.max_ltv_real_estate, c.max_ltv_equipment,
+               c.max_ltv_receivables, c.max_ltv_inventory,
+               c.personal_guarantee, c.guarantee_type,
+               c.decision_timeline_prequal_days,
+               c.decision_timeline_underwriting_days,
+               c.average_time_to_fund_days, c.special_conditions
+        FROM products p
+        JOIN banks b ON p.bank_id = b.id
+        LEFT JOIN product_eligibility e ON e.product_id = p.id
+        LEFT JOIN product_underwriting u ON u.product_id = p.id
+        LEFT JOIN product_collateral c ON c.product_id = p.id
+        WHERE p.product_type = %s
+        """,
+        (product_type,),
+    )
+    return [dict(r) for r in cur.fetchall()]
+
+
+# ---------- Filtering helpers ----------
+
+def passes_eligibility(product: Dict[str, Any], cust: Dict[str, Any]) -> Tuple[bool, str]:
+    """Return True if *product* passes eligibility for *cust*."""
+    # Entity type
+    allowed_entities = parse_csv(product.get("allowed_entities"))
+    if allowed_entities and cust.get("entity_type") not in allowed_entities:
+        return False, f"entity {cust.get('entity_type')} not allowed"
+
+    # Industry checks
+    allowed_ind = parse_csv(product.get("allowed_industries"))
+    excluded_ind = parse_csv(product.get("excluded_industries"))
+    industry = cust.get("industry", "")
+    if allowed_ind and industry not in allowed_ind:
+        return False, f"industry {industry} not allowed"
+    if excluded_ind and industry in excluded_ind:
+        return False, f"industry {industry} excluded"
+
+    # Geographic footprint
+    footprint = product.get("geographic_footprint") or product.get("bank_footprint")
+    states = parse_csv(footprint)
+    if states and cust.get("state") not in states:
+        return False, f"state {cust.get('state')} not in footprint"
+    excluded_states = parse_csv(product.get("excluded_states"))
+    if excluded_states and cust.get("state") in excluded_states:
+        return False, f"state {cust.get('state')} excluded"
+
+    # Years in business
+    min_years = product.get("min_years_in_business")
+    if min_years is not None and cust.get("years_in_business", 0) < float(min_years):
+        return False, "insufficient years in business"
+
+    # Revenue
+    min_rev = product.get("min_annual_revenue_usd")
+    if min_rev is not None and cust.get("annual_revenue_usd", 0) < float(min_rev):
+        return False, "insufficient revenue"
+
+    # Relationship requirement
+    if product.get("requires_existing_relationship"):
+        return False, "requires existing relationship"
+
+    return True, "passed"
+
+
+def passes_underwriting(product: Dict[str, Any], cust: Dict[str, Any]) -> Tuple[bool, str]:
+    """Return True if underwriting thresholds are met."""
+    fico = product.get("min_personal_credit_score")
+    if fico is not None and cust.get("personal_credit_score", 0) < float(fico):
+        return False, "personal credit below minimum"
+
+    bscore = product.get("min_business_credit_score")
+    if bscore is not None and cust.get("business_credit_score", 0) < float(bscore):
+        return False, "business credit below minimum"
+
+    dscr = product.get("min_dscr")
+    if dscr is not None and cust.get("dscr", 0) < float(dscr):
+        return False, "DSCR below minimum"
+
+    cur_ratio = product.get("min_current_ratio")
+    if cur_ratio is not None and cust.get("current_ratio", 0) < float(cur_ratio):
+        return False, "current ratio below minimum"
+
+    dte = product.get("max_debt_to_equity")
+    if dte is not None and cust.get("debt_to_equity", 0) > float(dte):
+        return False, "debt-to-equity above maximum"
+
+    if product.get("cashflow_positive_required") and not cust.get("cashflow_positive"):
+        return False, "requires positive cashflow"
+
+    ndays = product.get("negative_balance_days_avg")
+    if ndays is not None and cust.get("negative_balance_days_avg", 0) > float(ndays):
+        return False, "too many negative balance days"
+
+    nstreak = product.get("negative_balance_longest_streak")
+    if nstreak is not None and cust.get("negative_balance_longest_streak", 0) > float(nstreak):
+        return False, "negative balance streak too long"
+
+    nmax = product.get("negative_balance_max_overdraft_usd")
+    if nmax is not None and cust.get("negative_balance_max_overdraft_usd", 0) > float(nmax):
+        return False, "overdraft amount too large"
+
+    return True, "passed"
+
+
+def passes_deal(product: Dict[str, Any], cust: Dict[str, Any]) -> Tuple[bool, str]:
+    """Return True if requested deal fits product constraints."""
+    amt = cust.get("requested_amount_usd")
+    min_amt = product.get("min_loan_amount_usd")
+    max_amt = product.get("max_loan_amount_usd")
+    if min_amt is not None and amt is not None and float(amt) < float(min_amt):
+        return False, "amount below minimum"
+    if max_amt is not None and amt is not None and float(amt) > float(max_amt):
+        return False, "amount above maximum"
+
+    purposes = parse_csv(product.get("deal_purpose_allowed"))
+    if purposes and cust.get("use_of_proceeds") not in purposes:
+        return False, f"purpose {cust.get('use_of_proceeds')} not allowed"
+
+    return True, "passed"
+
+
+def compute_score(product: Dict[str, Any], cust: Dict[str, Any]) -> float:
+    """Compute a simple fit score for ranking purposes."""
+    score = 0.0
+    fico = product.get("min_personal_credit_score")
+    if fico is not None and cust.get("personal_credit_score") is not None:
+        score += W_FICO * (cust["personal_credit_score"] - float(fico)) / 100.0
+
+    dscr = product.get("min_dscr")
+    if dscr is not None and cust.get("dscr") is not None:
+        score += W_DSCR * (cust["dscr"] - float(dscr))
+
+    min_amt = product.get("min_loan_amount_usd")
+    max_amt = product.get("max_loan_amount_usd")
+    req = cust.get("requested_amount_usd")
+    if None not in (min_amt, max_amt, req) and float(max_amt) > float(min_amt):
+        mid = (float(max_amt) + float(min_amt)) / 2.0
+        half = (float(max_amt) - float(min_amt)) / 2.0
+        fit = 1 - abs(float(req) - mid) / half
+        score += W_AMOUNT * max(fit, 0)
+
+    ndays = product.get("negative_balance_days_avg")
+    if ndays is not None and cust.get("negative_balance_days_avg") is not None:
+        score += W_NEG_DAYS * (float(ndays) - cust["negative_balance_days_avg"]) / max(float(ndays), 1)
+
+    return score
+
+
+def match_products(conn, customer: Dict[str, Any], top: int) -> List[Dict[str, Any]]:
+    products = fetch_products(conn, customer["requested_product_type"])
+    results: List[Dict[str, Any]] = []
+    for p in products:
+        ok, _ = passes_eligibility(p, customer)
+        if not ok:
+            continue
+        ok, _ = passes_underwriting(p, customer)
+        if not ok:
+            continue
+        ok, _ = passes_deal(p, customer)
+        if not ok:
+            continue
+        score = compute_score(p, customer)
+        results.append({
+            "bank": p["bank_name"],
+            "product_id": p["id"],
+            "score": round(score, 4),
+            "min_amount": p.get("min_loan_amount_usd"),
+            "max_amount": p.get("max_loan_amount_usd"),
+        })
+    results.sort(key=lambda r: r["score"], reverse=True)
+    return results[:top]
+
+
+def main(argv: List[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(description="Match customer to bank products")
+    ap.add_argument("--dsn", required=True, help="Postgres DSN")
+    ap.add_argument("--customer-id", type=int)
+    ap.add_argument("--state")
+    ap.add_argument("--industry")
+    ap.add_argument("--entity-type")
+    ap.add_argument("--years", type=float, dest="years_in_business")
+    ap.add_argument("--revenue", type=float, dest="annual_revenue_usd")
+    ap.add_argument("--fico", type=float, dest="personal_credit_score")
+    ap.add_argument("--business-score", type=float, dest="business_credit_score")
+    ap.add_argument("--dscr", type=float)
+    ap.add_argument("--current-ratio", type=float)
+    ap.add_argument("--dte", type=float, dest="debt_to_equity")
+    ap.add_argument("--cashflow-positive", action="store_true")
+    ap.add_argument("--neg-days", type=float, dest="negative_balance_days_avg")
+    ap.add_argument("--neg-streak", type=float, dest="negative_balance_longest_streak")
+    ap.add_argument("--neg-max", type=float, dest="negative_balance_max_overdraft_usd")
+    ap.add_argument("--requested-product-type")
+    ap.add_argument("--requested-amount", type=float, dest="requested_amount_usd")
+    ap.add_argument("--use-of-proceeds")
+    ap.add_argument("--top", type=int, default=5)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    conn = psycopg2.connect(args.dsn)
+
+    if args.customer_id:
+        customer = fetch_customer(conn, args.customer_id)
+    else:
+        required = [
+            "state", "industry", "entity_type", "years_in_business",
+            "annual_revenue_usd", "personal_credit_score", "dscr",
+            "requested_product_type", "requested_amount_usd", "use_of_proceeds"
+        ]
+        missing = [f for f in required if getattr(args, f) is None]
+        if missing:
+            raise SystemExit(f"Missing required flags: {', '.join(missing)}")
+        customer = {
+            "state": args.state,
+            "industry": args.industry,
+            "entity_type": args.entity_type,
+            "years_in_business": args.years_in_business,
+            "annual_revenue_usd": args.annual_revenue_usd,
+            "personal_credit_score": args.personal_credit_score,
+            "business_credit_score": args.business_credit_score,
+            "dscr": args.dscr,
+            "current_ratio": args.current_ratio,
+            "debt_to_equity": args.debt_to_equity,
+            "cashflow_positive": args.cashflow_positive,
+            "negative_balance_days_avg": args.negative_balance_days_avg,
+            "negative_balance_longest_streak": args.negative_balance_longest_streak,
+            "negative_balance_max_overdraft_usd": args.negative_balance_max_overdraft_usd,
+            "requested_product_type": args.requested_product_type,
+            "requested_amount_usd": args.requested_amount_usd,
+            "use_of_proceeds": args.use_of_proceeds,
+        }
+
+    matches = match_products(conn, customer, args.top)
+
+    if args.json:
+        print(json.dumps(matches, indent=2))
+    else:
+        if not matches:
+            print("No matches found")
+        else:
+            print(f"Found {len(matches)} match(es):")
+            print(f"{'Bank':30} {'ProductID':10} {'Score':6} {'Amount Range'}")
+            for m in matches:
+                rng = f"{m['min_amount']} - {m['max_amount']}"
+                print(f"{m['bank'][:30]:30} {m['product_id']:10} {m['score']:<6} {rng}")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/tests/test_convert_json_to_csv.py
+++ b/etl/tests/test_convert_json_to_csv.py
@@ -1,0 +1,36 @@
+import csv
+import json
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path for direct module import
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+from etl.convert_json_to_csv import COLUMNS, FALLBACK_VALUE, convert_json_to_csv
+
+
+def test_convert_json_to_csv(tmp_path: Path):
+    data = [{
+        "bank_legal_name": "Example Bank",
+        "fdic_certificate": "99999",
+        "source_url": "https://example.com/loan",
+        "last_verified": "2024-01-01",
+        # leave out other fields to trigger fallback
+    }]
+    inp = tmp_path / "input.json"
+    inp.write_text(json.dumps(data), encoding="utf-8")
+    outp = tmp_path / "output.csv"
+
+    count = convert_json_to_csv(str(inp), str(outp))
+    assert count == 1 and outp.exists()
+
+    with outp.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == COLUMNS
+        row = next(reader)
+        # Provided fields should be preserved
+        assert row["bank_legal_name"] == "Example Bank"
+        assert row["fdic_certificate"] == "99999"
+        # Missing fields should be replaced with fallback value
+        assert row["website"] == FALLBACK_VALUE
+        assert row["industry_restrictions"] == FALLBACK_VALUE

--- a/etl/tests/test_match_customer.py
+++ b/etl/tests/test_match_customer.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from etl.match_customer import (
+    passes_eligibility,
+    passes_underwriting,
+    passes_deal,
+    compute_score,
+)
+
+
+def make_product():
+    return {
+        "id": 1,
+        "bank_name": "Sample Bank",
+        "allowed_entities": "LLC,S-Corp",
+        "allowed_industries": "Restaurants,Retail",
+        "excluded_industries": "Cannabis",
+        "geographic_footprint": "CA,NY",
+        "excluded_states": "NV",
+        "min_years_in_business": 2,
+        "min_annual_revenue_usd": 100000,
+        "requires_existing_relationship": False,
+        "min_personal_credit_score": 680,
+        "min_business_credit_score": 650,
+        "min_dscr": 1.2,
+        "min_current_ratio": 1.1,
+        "max_debt_to_equity": 3.0,
+        "cashflow_positive_required": True,
+        "negative_balance_days_avg": 3,
+        "negative_balance_longest_streak": 5,
+        "negative_balance_max_overdraft_usd": 5000,
+        "min_loan_amount_usd": 50000,
+        "max_loan_amount_usd": 250000,
+        "deal_purpose_allowed": "WorkingCapital,Equipment",
+    }
+
+
+def make_customer():
+    return {
+        "entity_type": "LLC",
+        "industry": "Restaurants",
+        "state": "CA",
+        "years_in_business": 3,
+        "annual_revenue_usd": 500000,
+        "personal_credit_score": 700,
+        "business_credit_score": 660,
+        "dscr": 1.3,
+        "current_ratio": 1.2,
+        "debt_to_equity": 2.5,
+        "cashflow_positive": True,
+        "negative_balance_days_avg": 2,
+        "negative_balance_longest_streak": 3,
+        "negative_balance_max_overdraft_usd": 3000,
+        "requested_amount_usd": 150000,
+        "use_of_proceeds": "WorkingCapital",
+    }
+
+
+def test_eligibility_and_underwriting_pass():
+    product = make_product()
+    customer = make_customer()
+    assert passes_eligibility(product, customer)[0]
+    assert passes_underwriting(product, customer)[0]
+
+
+def test_deal_and_score():
+    product = make_product()
+    customer = make_customer()
+    ok, _ = passes_deal(product, customer)
+    assert ok
+    score = compute_score(product, customer)
+    assert score > 0

--- a/scripts/dev/batch.ps1
+++ b/scripts/dev/batch.ps1
@@ -1,0 +1,19 @@
+param(
+  [Parameter(Mandatory=$true)] [string]$InJson,
+  [Parameter(Mandatory=$true)] [string]$OutCsv
+)
+
+$dc = "docker compose -f infra/compose.yaml"
+
+# Convert
+iex "$dc run --rm etl bash -lc 'python etl/convert_json_to_csv.py $InJson $OutCsv'"
+if ($LASTEXITCODE -ne 0) { Write-Error "Conversion failed"; exit 1 }
+
+# Load
+iex "$dc up -d db"
+iex "$dc exec -T db psql -U bankmatch -d bankmatch -f /migrations/0001_init.sql"
+iex "$dc run --rm etl bash -lc 'python etl/ingest_csv.py --dsn postgres://bankmatch:bankmatch@db:5432/bankmatch --csv $OutCsv'"
+if ($LASTEXITCODE -ne 0) { Write-Error "Ingest failed"; exit 1 }
+
+# Verify
+iex "$dc exec -T db psql -U bankmatch -d bankmatch -c 'SELECT count(*) AS banks FROM banks; SELECT count(*) AS products FROM products;'"


### PR DESCRIPTION
## Summary
- Add `product_eligibility`, `product_underwriting`, `product_collateral`, and `customer_profiles` tables for matching
- Implement `match_customer.py` CLI that filters products through eligibility, underwriting, and deal checks and ranks matches
- Provide Make targets and sample SQL data for seeding and demonstrating customer-to-product matching

## Testing
- `pytest -q`
- `make migrate2` *(fails: docker: No such file or directory)*
- `make match CID=1` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5c37ad2408327a19613f396feb66a