### PR TITLE
Add credit box schema and scoring skeleton

### DIFF
--- a/GAP_REPORT.md
+++ b/GAP_REPORT.md
@@ -1,0 +1,76 @@
+# Underwriting Matching Engine GAP Report
+
+## 1. Repo Inventory
+- **app/** – Python requirements for ETL scripts.
+- **apps/api/** – FastAPI service with health and root endpoints.
+- **data/** – Sample data and templates used in demos.
+- **db/** – SQL migrations defining bank/product and matching schemas.
+- **etl/** – CSV conversion, ingestion, and rudimentary matching script with tests.
+- **infra/** – Docker compose file for Postgres and ETL container.
+- **scripts/** – Developer utility scripts.
+- *(New)* **src/** – placeholder for parsers, features, scoring modules.
+
+## 2. Current vs Target Matrix
+| Component | Exists? | Quality | Gaps | Immediate Fix |
+|-----------|--------|--------|------|---------------|
+| Ingestion (PDF/Plaid) | Partial | Low | Only CSV→DB via scripts; no API integrations | Implement API connectors, robust error handling |
+| OCR/Parsing | No | – | No PDF/tax parsers | Add bank statement/tax parsers |
+| Normalization & Validation | Partial | Med | CSV validation only; no schema enforcement | Introduce Pydantic models & JSON schema |
+| Feature Engineering | No | – | KPIs not computed | Add financial feature module |
+| Lender Credit Box | Partial | Low | SQL tables but no config abstraction | YAML/JSON schema for lender criteria |
+| Scoring & Rules Engine | Partial | Low | Simple heuristics in `match_customer.py`; no reusable engine | Create modular rules engine |
+| Matching & Ranking | Yes | Med | Heuristic scoring only | Integrate with rules engine & weights |
+| Explainability | No | – | No rationale tracking | Add reasons in rules engine |
+| Export/Reporting | No | – | No underwriting package generation | Build reporting module |
+| API, Auth, Audit Logs | Minimal | Low | Bare health endpoint; no auth/logging | Expand API with auth and audit trails |
+| Data Model/DB Schemas | Yes | Med | Lacks relationships for lenders, criteria versioning | Extend schema for credit boxes |
+| Tests | Yes | Low | Only ETL scripts covered | Add unit tests for new modules |
+| Security/Compliance | No | – | No PII handling, secrets mgmt | Implement encryption, access controls |
+
+## 3. Data Flow
+1. **Document/API upload** – client submits bank or tax docs (not yet implemented).
+2. **Parsing/OCR** – extract transactions and financials from PDFs.
+3. **Normalization & Validation** – map to canonical schema, validate types/units.
+4. **Feature Engineering** – compute KPIs such as revenue, DSCR, balances.
+5. **Rules/Scoring** – evaluate against lender credit boxes, produce scores.
+6. **Matching & Ranking** – select best lenders/programs for the client.
+7. **Export/Reporting** – generate underwriting summary for brokers/lenders.
+
+## 4. Lender Credit Box (Schema + Samples)
+- See `schemas/lender_credit_box.schema.json` for proposed schema.
+- Sample lender configs in `configs/lenders.sample.yaml` illustrate SBA and equipment lenders with eligibility criteria.
+
+## 5. KPIs & Ratios (Formulas + Edge Cases)
+- **avg_daily_balance** = sum(daily balances) / N; handle empty lists.
+- **month_over_month_revenue** = (M_i - M_{i-1}) / M_{i-1}; guard against division by zero.
+- **inflows_outflows** = sum deposits vs withdrawals; classify transfers.
+- **nsf_count** = count of negative balance days; clarify overlapping fees.
+- **dscr** = EBITDA / annual_debt_service; return `None` when debt service is 0.
+- **add_backs** = interest + depreciation + amortization + owner_comp adjustments.
+
+## 6. Scoring & Matching (Code/Pseudocode)
+- Rules engine evaluates hard filters then soft-score rules:
+```python
+from src.scoring.rules_engine import Rule, RulesEngine
+engine = RulesEngine([
+    Rule("personal_fico", ">=", 660, hard=True),
+    Rule("dscr", ">=", 1.15, weight=50, hard=False),
+    Rule("years_in_business", ">=", 2, weight=50, hard=False)
+])
+result = engine.evaluate(metrics)
+```
+- TODO: support weighted scorecard, rationale tracking, config-driven rules.
+
+## 7. Security & Compliance Gaps
+- No encryption or secrets management.
+- No authentication/authorization around API or data access.
+- Missing audit logs, PII redaction, or consent flows.
+- Need error logging, data retention policies, and secure storage of documents.
+
+## 8. Testing Plan (with Sample Tests)
+- Existing tests cover ETL utilities only.
+- New unit tests added for rules engine and financial features.
+- Future tests:
+  - Parser fixtures with synthetic PDFs.
+  - Integration tests for matching against sample credit boxes.
+  - Security tests for auth and permission checks.

--- a/configs/lenders.sample.yaml
+++ b/configs/lenders.sample.yaml
@@ -1,0 +1,25 @@
+- name: LenderAlpha
+  program: ["SBA_7a", "Term"]
+  loan_amount_min: 50000
+  loan_amount_max: 5000000
+  min_years_in_business: 2
+  min_personal_fico: 660
+  min_revenue_ttm: 300000
+  dscr_min: 1.15
+  industry_blacklist: ["Cannabis", "Adult"]
+  states_allowed: ["ALL"]
+  collateral_types: ["UCC", "RE", "Equipment"]
+  docs_required: ["BankStatements_3m", "TaxReturns_2y"]
+
+- name: EquipFast
+  program: ["Equipment"]
+  loan_amount_min: 20000
+  loan_amount_max: 1000000
+  min_years_in_business: 1
+  min_personal_fico: 620
+  min_revenue_ttm: 200000
+  dscr_min: 1.10
+  industry_blacklist: []
+  states_allowed: ["CA", "NY", "TX", "FL", "GA"]
+  collateral_types: ["Equipment"]
+  docs_required: ["BankStatements_6m"]

--- a/schemas/lender_credit_box.schema.json
+++ b/schemas/lender_credit_box.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/lender_credit_box.schema.json",
+  "title": "LenderCreditBox",
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "program": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Supported loan programs"
+    },
+    "loan_amount_min": {"type": "number"},
+    "loan_amount_max": {"type": "number"},
+    "min_years_in_business": {"type": "number"},
+    "min_personal_fico": {"type": "number"},
+    "min_revenue_ttm": {"type": "number"},
+    "dscr_min": {"type": "number"},
+    "collateral_types": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "industry_blacklist": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "states_allowed": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "docs_required": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "required": [
+    "name",
+    "program",
+    "loan_amount_min",
+    "loan_amount_max"
+  ]
+}

--- a/src/features/financial_features.py
+++ b/src/features/financial_features.py
@@ -1,0 +1,32 @@
+"""Financial feature calculations used by the underwriting engine."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+
+def avg_daily_balance(balances: List[float]) -> Optional[float]:
+    """Return the arithmetic mean of daily balances.
+
+    Returns ``None`` when *balances* is empty.
+    """
+    if not balances:
+        return None
+    return sum(balances) / len(balances)
+
+
+def dscr(ebitda: float, annual_debt_service: float) -> Optional[float]:
+    """Debt Service Coverage Ratio = EBITDA / Annual Debt Service."""
+    if annual_debt_service == 0:
+        return None
+    return ebitda / annual_debt_service
+
+
+def month_over_month_growth(values: List[float]) -> List[Optional[float]]:
+    """Return percentage growth for each month compared to previous month."""
+    growth: List[Optional[float]] = []
+    for prev, curr in zip(values, values[1:]):
+        if prev == 0:
+            growth.append(None)
+        else:
+            growth.append((curr - prev) / prev)
+    return growth

--- a/src/parsers/bank_statement_parser.py
+++ b/src/parsers/bank_statement_parser.py
@@ -1,0 +1,15 @@
+"""Bank statement parser interface."""
+from __future__ import annotations
+
+from typing import Dict
+
+
+def parse(pdf_bytes: bytes) -> Dict[str, str]:
+    """Parse *pdf_bytes* and return structured data.
+
+    TODO:
+        * Integrate OCR/ML models to extract transactions and balances.
+        * Support multiple bank formats and error handling.
+    """
+    # Placeholder implementation
+    return {}

--- a/src/scoring/rules_engine.py
+++ b/src/scoring/rules_engine.py
@@ -1,0 +1,73 @@
+"""Rule-based credit evaluation engine.
+
+This module implements a minimal rule processor used to evaluate borrower metrics
+against lender credit boxes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List
+
+# Supported comparison operators
+OPERATORS: Dict[str, Callable[[float, float], bool]] = {
+    ">=" : lambda a, b: a >= b,
+    "<=" : lambda a, b: a <= b,
+    ">"  : lambda a, b: a > b,
+    "<"  : lambda a, b: a < b,
+    "==" : lambda a, b: a == b,
+}
+
+
+@dataclass
+class Rule:
+    """Single evaluation rule.
+
+    Attributes:
+        field: Metric name to evaluate.
+        op: Comparison operator as string.
+        threshold: Numeric threshold to compare against.
+        weight: Weight used for soft scoring.
+        hard: If True, failure results in immediate decline.
+    """
+
+    field: str
+    op: str
+    threshold: float
+    weight: float = 1.0
+    hard: bool = True
+
+
+class RulesEngine:
+    """Evaluate metrics using a list of :class:`Rule` objects.
+
+    TODO:
+        * Load rules from YAML/JSON configuration files.
+        * Support nested AND/OR groups and custom functions.
+        * Persist detailed decline reasons for audit purposes.
+    """
+
+    def __init__(self, rules: List[Rule]):
+        self.rules = rules
+
+    def evaluate(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        """Return evaluation result with approval flag and score."""
+        score = 0.0
+        reasons: List[str] = []
+        for rule in self.rules:
+            func = OPERATORS.get(rule.op)
+            if not func:
+                reasons.append(f"unknown operator {rule.op}")
+                continue
+            value = metrics.get(rule.field)
+            if value is None or not func(value, rule.threshold):
+                reasons.append(
+                    f"{rule.field} {rule.op} {rule.threshold} failed (value={value})"
+                )
+                if rule.hard:
+                    return {"approved": False, "score": score, "reasons": reasons}
+            else:
+                if not rule.hard:
+                    score += rule.weight
+        max_weight = sum(r.weight for r in self.rules if not r.hard)
+        pct = (score / max_weight * 100.0) if max_weight > 0 else 0.0
+        return {"approved": True, "score": pct, "reasons": reasons}

--- a/tests/test_financial_features.py
+++ b/tests/test_financial_features.py
@@ -1,0 +1,15 @@
+from src.features.financial_features import avg_daily_balance, dscr, month_over_month_growth
+
+def test_avg_daily_balance():
+    assert avg_daily_balance([100.0, 200.0, 300.0]) == 200.0
+    assert avg_daily_balance([]) is None
+
+
+def test_dscr():
+    assert dscr(120.0, 100.0) == 1.2
+    assert dscr(100.0, 0.0) is None
+
+
+def test_month_over_month_growth():
+    assert month_over_month_growth([100.0, 110.0, 121.0]) == [0.1, 0.1]
+    assert month_over_month_growth([0.0, 50.0]) == [None]

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -1,0 +1,22 @@
+from src.scoring.rules_engine import Rule, RulesEngine
+
+
+def test_rules_engine_approves_and_scores():
+    rules = [
+        Rule("fico", ">=", 660, hard=True),
+        Rule("dscr", ">=", 1.2, weight=50, hard=False),
+        Rule("years", ">=", 2, weight=50, hard=False),
+    ]
+    engine = RulesEngine(rules)
+    metrics = {"fico": 700, "dscr": 1.3, "years": 5}
+    result = engine.evaluate(metrics)
+    assert result["approved"] is True
+    assert result["score"] == 100.0
+
+
+def test_rules_engine_declines_on_hard_rule():
+    rules = [Rule("fico", ">=", 700, hard=True)]
+    engine = RulesEngine(rules)
+    metrics = {"fico": 650}
+    result = engine.evaluate(metrics)
+    assert result["approved"] is False


### PR DESCRIPTION
## Summary
- define JSON schema and sample YAML for lender credit boxes
- add rule-based scoring engine and financial feature utilities
- provide gap analysis report and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b8b0fa31108327808b798a7e91e67d